### PR TITLE
Mapping caused duplicate Independence Day holidays

### DIFF
--- a/DateTimeExtensions.Tests/ExampleTests.cs
+++ b/DateTimeExtensions.Tests/ExampleTests.cs
@@ -217,6 +217,24 @@ namespace DateTimeExtensions.Tests
         }
 
         [Test]
+        public void get_us_holidays_in_2015_passes()
+        {
+            var usWorkingDayCultureInfo = new WorkingDayCultureInfo("en-US");
+            var today = new DateTime(2015, 1, 1);
+            var holidays = today.AllYearHolidays(usWorkingDayCultureInfo);
+
+            Assert.IsTrue(holidays.Count == 10, "expecting 10 holidays but got {0}", holidays.Count);
+
+            foreach (DateTime holidayDate in holidays.Keys)
+            {
+                var holiday = holidays[holidayDate];
+                Assert.IsTrue(holidayDate.IsWorkingDay(usWorkingDayCultureInfo) == false,
+                    "holiday {0} shouln't be working day in US", holiday.Name);
+            }
+            
+        }
+
+        [Test]
         public void get_next_and_last_tuesday()
         {
             var a_saturday = new DateTime(2011, 8, 20);

--- a/DateTimeExtensions/WorkingDays/CultureStrategies/EN_USHolidayStrategy.cs
+++ b/DateTimeExtensions/WorkingDays/CultureStrategies/EN_USHolidayStrategy.cs
@@ -53,15 +53,17 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
                 if (date.HasValue)
                 {
                     //if the holiday is a saturday, the holiday is observed on previous friday
-                    if (date.Value.DayOfWeek == DayOfWeek.Saturday)
+                    switch (date.Value.DayOfWeek)
                     {
-                        holidayMap.Add(date.Value.AddDays(-1), innerHoliday);
-                    }
-                    holidayMap.Add(date.Value, innerHoliday);
-                    //if the holiday is a sunday, the holiday is observed on next monday
-                    if (date.Value.DayOfWeek == DayOfWeek.Sunday)
-                    {
-                        holidayMap.Add(date.Value.AddDays(1), innerHoliday);
+                        case DayOfWeek.Saturday:
+                            holidayMap.Add(date.Value.AddDays(-1), innerHoliday);
+                            break;
+                        case DayOfWeek.Sunday:
+                            holidayMap.Add(date.Value.AddDays(1), innerHoliday);
+                            break;
+                        default:
+                            holidayMap.Add(date.Value, innerHoliday);
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
AllYearHolidays() is failing for US holidays in 2015 because Independence Day falls on a Saturday and gets added to the mapping twice.
