### PR TITLE
Updated da-DK holiday strategy to reflect recent abolishment of  'General Prayer Day' in Denmark.

### DIFF
--- a/src/DateTimeExtensions/WorkingDays/CultureStrategies/DA_DKHolidayStrategy.cs
+++ b/src/DateTimeExtensions/WorkingDays/CultureStrategies/DA_DKHolidayStrategy.cs
@@ -61,6 +61,7 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
         //source: http://en.wikipedia.org/wiki/Store_Bededag
         // Store Bededag, translated literally as Great Prayer Day or more loosely as General Prayer Day, "All Prayers" Day, Great Day of Prayers or Common Prayer Day,
         //is a Danish holiday celebrated on the 4th Friday after Easter
+        //NB: On 28 February 2023, the Danish Parliament voted to abolish Store Bededag, effective from 2024. See wiki link above.
         private static Holiday generalPrayerDay;
 
         public static Holiday GeneralPrayerDay
@@ -69,8 +70,8 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
             {
                 if (generalPrayerDay == null)
                 {
-                    generalPrayerDay = new NthDayOfWeekAfterDayHoliday("General Prayer Day", 4, DayOfWeek.Friday,
-                        ChristianHolidays.Easter);
+                    generalPrayerDay = new YearDependantHoliday(year => year < 2024, new NthDayOfWeekAfterDayHoliday("General Prayer Day", 4, DayOfWeek.Friday,
+                        ChristianHolidays.Easter));
                 }
                 return generalPrayerDay;
             }

--- a/tests/DateTimeExtensions.Tests/DaDkHolidaysTests.cs
+++ b/tests/DateTimeExtensions.Tests/DaDkHolidaysTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using DateTimeExtensions.WorkingDays;
+using DateTimeExtensions.WorkingDays.CultureStrategies;
+using NUnit.Framework;
+
+namespace DateTimeExtensions.Tests
+{
+    [TestFixture]
+    public class DaDkHolidaysTests
+    {
+        [Test]
+        public void Can_get_strategy()
+        {
+            var dateTimeCulture = new WorkingDayCultureInfo("da-DK");
+            var strategy = dateTimeCulture.LocateHolidayStrategy(dateTimeCulture.Name, null);
+            Assert.AreEqual(typeof(DA_DKHolidayStrategy), strategy.GetType());
+        }
+
+        [Test]
+        public void Assert_holidays_count()
+        {
+            var dateTimeCulture = new WorkingDayCultureInfo("da-DK");
+            var holidays = dateTimeCulture.Holidays;
+            Assert.AreEqual(11, holidays.Count());
+        }
+
+        [Test]
+        public void StoreBededagIsHolidayIn2023()
+        {
+            var dateTimeCulture = new WorkingDayCultureInfo("da-DK");
+            var storeBedeDag =
+                new NthDayOfWeekAfterDayHoliday("General Prayer Day", 4, DayOfWeek.Friday, ChristianHolidays.Easter)
+                    .GetInstance(2023);
+
+            Assert.IsNotNull(storeBedeDag);
+            Assert.IsTrue(dateTimeCulture.IsHoliday(storeBedeDag.Value));
+        }
+
+        [Test]
+        public void StoreBededagIsNotHolidayIn2024()
+        {
+            var dateTimeCulture = new WorkingDayCultureInfo("da-DK");
+            var storeBedeDag =
+                new NthDayOfWeekAfterDayHoliday("General Prayer Day", 4, DayOfWeek.Friday, ChristianHolidays.Easter)
+                    .GetInstance(2024);
+
+            Assert.IsNotNull(storeBedeDag);
+            Assert.IsFalse(dateTimeCulture.IsHoliday(storeBedeDag.Value));
+        }
+    }
+}


### PR DESCRIPTION
* Updated da-DK holiday strategy to reflect recent abolishment of  'General Prayer Day' in Denmark.
* See: https://en.wikipedia.org/wiki/Store_Bededag#Elimination_in_2023