### PR TITLE
Implemented IWorkingDayCultureInfo Interface in GetWorkingDays Method

### DIFF
--- a/src/DateTimeExtensions/WorkingDaysExtensions.cs
+++ b/src/DateTimeExtensions/WorkingDaysExtensions.cs
@@ -1,7 +1,7 @@
 #region License
 
 // 
-// Copyright (c) 2011-2012, João Matos Silva <kappy@acydburne.com.pt>
+// Copyright (c) 2011-2012, Joï¿½o Matos Silva <kappy@acydburne.com.pt>
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ namespace DateTimeExtensions
         /// <param name="to">The end day.</param>
         /// <param name="workingDayCultureInfo">The culture of working days to be used in the calculation. See <seealso cref="WorkingDayCultureInfo"/> for more information.</param>
         /// <returns>the number of Workingdays in the range <paramref name="from"/> / <paramref name="to"/></returns>
-        public static int GetWorkingDays(this DateTime from, DateTime to, WorkingDayCultureInfo workingDayCultureInfo)
+        public static int GetWorkingDays(this DateTime from, DateTime to, IWorkingDayCultureInfo workingDayCultureInfo)
         {
             var innerFrom = from < to ? from : to;
             var innerTo = from < to ? to : from;
@@ -100,7 +100,9 @@ namespace DateTimeExtensions
         /// <returns>the number of Workingdays in the range <paramref name="from"/> / <paramref name="to"/></returns>
         public static int GetWorkingDays(this DateTime from, DateTime to)
         {
-            return GetWorkingDays(from, to, new WorkingDayCultureInfo());
+            var workingDayCultureInfo = new WorkingDayCultureInfo();
+
+            return GetWorkingDays(from, to, workingDayCultureInfo);
         }
 
         /// <summary>


### PR DESCRIPTION
The original version of the GetWorkingDays method used the concrete class WorkingDayCultureInfo. This means that the method was tightly coupled with this specific class. If you wanted to use a different implementation of working day calculations for a different culture or a different set of rules, you would have to change the method itself or create a new one.

The change I suggested was to use the IWorkingDayCultureInfo interface instead of the WorkingDayCultureInfo concrete class. This makes the method more flexible and adaptable. Now, it can work with any class that implements the IWorkingDayCultureInfo interface. This is a principle known as programming to an interface, not an implementation.

With this change, if you have a different class that implements the IWorkingDayCultureInfo interface, you can use it directly with the GetWorkingDays method without any changes to the method itself. This makes your code more reusable and easier to maintain. 