### PR TITLE
Added Teacher's Day in IndianHolidayStrategy.cs

### DIFF
--- a/src/DateTimeExtensions/WorkingDays/CultureStrategies/IndianHolidayStrategy.cs
+++ b/src/DateTimeExtensions/WorkingDays/CultureStrategies/IndianHolidayStrategy.cs
@@ -15,6 +15,7 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
             this.InnerHolidays.Add(IndependenceDay);
             this.InnerHolidays.Add(RepublicDay);
             this.InnerHolidays.Add(GandhiBirthAnniversary);
+            this.InnerHolidays.Add(TeachersDay);
 
         }
         private static Holiday independenceDay;
@@ -57,5 +58,10 @@ namespace DateTimeExtensions.WorkingDays.CultureStrategies
                 return gandhiBirthAnniversary;
             }
         }
+
+
+        private static Holiday teachersDay;
+        public static Holiday TeachersDay =>
+            teachersDay ??= new FixedHoliday("Teacher's Day", 9, 5, IndianCalendar);
     }
 }


### PR DESCRIPTION
This PR introduces Teacher's Day (September 5) as a fixed holiday in the IndianHolidayStrategy class. Celebrated across India in honor of Dr. Sarvepalli Radhakrishnan, Teacher's Day is now included in the list of recognized public holidays.

Why: To ensure culturally significant holidays like Teacher's Day are considered in Indian working day calculations.