### PR TITLE
Add Albanian Public Holidays as Rest Days

### DIFF
--- a/src/DateTimeExtensions/NaturalText/CultureStrategies/SQ_ALNaturalTimeStrategy.cs
+++ b/src/DateTimeExtensions/NaturalText/CultureStrategies/SQ_ALNaturalTimeStrategy.cs
@@ -1,0 +1,62 @@
+using DateTimeExtensions.Common;
+using System;
+
+namespace DateTimeExtensions.NaturalText.CultureStrategies
+{
+    [Locale("sq-AL")]
+    public class SQ_ALNaturalTimeStrategy : NaturalTimeStrategyBase
+    {
+        protected override string YearText => "vit";
+        protected override string MonthText => "muaj";
+        protected override string DayText => "ditë";
+        protected override string HourText => "orë";
+        protected override string MinuteText => "minutë";
+        protected override string SecondText => "sekondë";
+
+        protected override string Pluralize(string text, int value)
+        {
+            if (value == 1)
+            {
+                // Singular forms
+                switch (text.ToLowerInvariant())
+                {
+                    case "vit":
+                        return "një vit";
+                    case "muaj":
+                        return "një muaj";
+                    case "ditë":
+                        return "një ditë";
+                    case "orë":
+                        return "një orë";
+                    case "minutë":
+                        return "një minutë";
+                    case "sekondë":
+                        return "një sekondë";
+                    default:
+                        return text;
+                }
+            }
+            else
+            {
+                // Plural forms
+                switch (text.ToLowerInvariant())
+                {
+                    case "vit":
+                        return "vite";
+                    case "muaj":
+                        return "muaj";
+                    case "ditë":
+                        return "ditë";
+                    case "orë":
+                        return "orë";
+                    case "minutë":
+                        return "minuta";
+                    case "sekondë":
+                        return "sekonda";
+                    default:
+                        return text;
+                }
+            }
+        }
+    }
+}

--- a/src/DateTimeExtensions/WorkingDays/CultureStrategies/AL_SQHolidayStrategy.cs
+++ b/src/DateTimeExtensions/WorkingDays/CultureStrategies/AL_SQHolidayStrategy.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using DateTimeExtensions.Common;
+
+// Albanian Holidays 
+
+namespace DateTimeExtensions.WorkingDays.CultureStrategies
+{
+    [Locale("sq-AL")]
+
+    public class SQ_ALHolidayStrategy : HolidayStrategyBase, IHolidayStrategy
+    {
+        public SQ_ALHolidayStrategy()
+        {
+            this.InnerHolidays.Add(GlobalHolidays.NewYear);
+            this.InnerHolidays.Add(SummerDay); // Dita e Veres in Albanian
+            this.InnerHolidays.Add(ChristianHolidays.Easter);
+            this.InnerHolidays.Add(ChristianOrthodoxHolidays.Easter);
+            this.InnerHolidays.Add(NewruzDay); // Dita e Nevruzit Shia Muslim
+            this.InnerHolidays.Add(GlobalHolidays.InternationalWorkersDay);
+            this.InnerHolidays.Add(MotherTheresaDay); // St. Theresa Day
+            this.InnerHolidays.Add(AlphabetDay);
+            this.InnerHolidays.Add(IndependenceDay);
+            this.InnerHolidays.Add(LiberationDay);
+            this.InnerHolidays.Add(NationalYouthDay);
+            this.InnerHolidays.Add(ChristianHolidays.Christmas);
+            this.InnerHolidays.Add(NewYearHoliday2); // second day of new year is a holiday in Albanian
+
+        }
+        private static Holiday newYearHoliday2;
+        public static Holiday NewYearHoliday2
+        {
+            get
+            {
+                if (newYearHoliday2 == null)
+                {
+                    newYearHoliday2 = new FixedHoliday("NewYearHoliday2", 1, 2);
+                }
+                return newYearHoliday2;
+            }
+        }
+
+        private static Holiday summerDay;
+        public static Holiday SummerDay
+        {
+            get
+            {
+                if (summerDay == null)
+                {
+                    summerDay = new FixedHoliday("SummerDay", 3, 14);
+                }
+                return summerDay;
+            }
+
+
+        }
+
+        // This is a Shia Muslim Holiday 
+        private static Holiday newruzDay;
+        public static Holiday NewruzDay
+        {
+            get
+            {
+                if (newruzDay == null)
+                {
+                    newruzDay = new FixedHoliday("NevruzDay", 3, 22);
+                }
+                return newruzDay;
+            }
+        }
+
+        // Saint Theresa or known as Mother Theresa
+        private static Holiday motherTheresaDay;
+        public static Holiday MotherTheresaDay
+        {
+            get
+            {
+                if (motherTheresaDay == null)
+                {
+                    motherTheresaDay = new FixedHoliday("MotherTheresaDay", 9, 5);
+                }
+                return motherTheresaDay;
+            }
+        }
+
+        private static Holiday alphabetDay;
+        public static Holiday AlphabetDay
+        {
+            get
+            {
+                if (alphabetDay == null)
+                {
+                    alphabetDay = new FixedHoliday("AlphabetDay", 11, 22);
+                }
+                return alphabetDay;
+            }
+
+
+        }
+
+        private static Holiday independenceDay;
+        public static Holiday IndependenceDay
+        {
+            get
+            {
+                if (independenceDay == null)
+                {
+                    independenceDay = new FixedHoliday("IndipedenceDay", 11, 28);
+
+                }
+                return independenceDay;
+            }
+        }
+
+        private static Holiday liberationDay;
+        public static Holiday LiberationDay
+        {
+            get
+            {
+                if (liberationDay == null)
+                {
+                    liberationDay = new FixedHoliday("LiberationDay", 11, 29);
+                }
+                return liberationDay;
+            }
+        }
+
+        private static Holiday nationalYouthDay;
+
+        public static Holiday NationalYouthDay
+        {
+            get
+            {
+                if (nationalYouthDay == null)
+                {
+                    nationalYouthDay = new FixedHoliday("NationalYouthDay", 12, 8);
+                }
+                return nationalYouthDay;
+            }
+        }
+
+
+        public IEnumerable<Holiday> GetHolidays()
+        {
+            return this.InnerHolidays;
+        }
+    
+    }
+}

--- a/tests/DateTimeExtensions.Tests/AlbanianHolidaysTests.cs
+++ b/tests/DateTimeExtensions.Tests/AlbanianHolidaysTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using DateTimeExtensions.WorkingDays;
+using DateTimeExtensions.WorkingDays.CultureStrategies;
+using NUnit.Framework;
+
+namespace DateTimeExtensions.Tests
+{
+    [TestFixture]
+    public class AlbanianHolidayTests
+    {
+        private WorkingDayCultureInfo albanianCulture;
+
+        [SetUp]
+        public void Setup()
+        {
+            albanianCulture = new WorkingDayCultureInfo("sq-AL");
+        }
+
+        [Test]
+        public void FixedDateHolidays_AreCorrect()
+        {
+            Assert.IsTrue(albanianCulture.IsHoliday(new DateTime(2025, 1, 1)));
+
+            Assert.IsTrue(albanianCulture.IsHoliday(new DateTime(2025, 1, 2)));
+
+            Assert.IsTrue(albanianCulture.IsHoliday(new DateTime(2025, 3, 14)));
+
+            Assert.IsTrue(albanianCulture.IsHoliday(new DateTime(2025, 3, 22)));
+        }
+
+        [Test]
+        public void Easter_IsRecognized()
+        {
+            Assert.IsTrue(albanianCulture.IsHoliday(new DateTime(2025, 4, 20)));
+
+            Assert.IsTrue(albanianCulture.IsHoliday(new DateTime(2025, 4, 20)));
+        }
+
+        [Test]
+        public void HolidayCount_2025_IsCorrect()
+        {
+            var holidays2025 = albanianCulture.GetHolidaysOfYear(2025).ToList();
+            Assert.AreEqual(12, holidays2025.Count); // easters were both on the same day in 2025 resulting in 12 unique holidays
+        }
+
+        [Test]
+        public void Strategy_Holidays_AreCorrect()
+        {
+
+            // Independence Day (November 28)
+            var independenceDate = SQ_ALHolidayStrategy.IndependenceDay.GetInstance(2025);
+            Assert.AreEqual(new DateTime(2025, 11, 28), independenceDate);
+
+            // Mother Teresa Day (September 5)
+            var teresaDate = SQ_ALHolidayStrategy.MotherTheresaDay.GetInstance(2025);
+            Assert.AreEqual(new DateTime(2025, 9, 5), teresaDate);
+        }
+
+        [Test]
+        public void WeekendHolidays_AreStillObserved()
+        {
+            Assert.IsTrue(albanianCulture.IsHoliday(new DateTime(2023, 1, 1)));
+        }
+    }
+}

--- a/tests/DateTimeExtensions.Tests/SQ_ALNaturalTimeStrategyTests.cs
+++ b/tests/DateTimeExtensions.Tests/SQ_ALNaturalTimeStrategyTests.cs
@@ -1,0 +1,94 @@
+using System;
+using DateTimeExtensions.NaturalText;
+using NUnit.Framework;
+
+namespace DateTimeExtensions.Tests
+{
+    [TestFixture]
+    public class SQ_ALNaturalTimeTests
+    {
+        private NaturalTextCultureInfo al_ci = new NaturalTextCultureInfo("sq-AL");
+        private DateTime fromTime = new DateTime(2024, 5, 8, 9, 41, 0);
+
+        [Test]
+        public void can_translate_to_natural_text_al()
+        {
+            var toTime = fromTime.AddHours(2).AddMinutes(45);
+
+            var naturalText = fromTime.ToNaturalText(toTime, false, al_ci);
+
+            Assert.IsNotNull(naturalText);
+            Assert.IsNotEmpty(naturalText);
+            Assert.AreEqual("2 orë", naturalText);
+        }
+
+        [Test]
+        public void can_translate_to_natural_text_rounded_al()
+        {
+            var toTime = fromTime.AddHours(2).AddMinutes(45);
+
+            var naturalText = fromTime.ToNaturalText(toTime, true, al_ci);
+
+            Assert.IsNotNull(naturalText);
+            Assert.IsNotEmpty(naturalText);
+            Assert.AreEqual("3 orë", naturalText); 
+        }
+
+        [Test]
+        public void can_translate_to_exact_natural_text_full_al()
+        {
+            var toTime = fromTime
+                .AddSeconds(6)
+                .AddMinutes(5)
+                .AddHours(4)
+                .AddDays(3)
+                .AddMonths(2)
+                .AddYears(2);
+
+            var naturalText = fromTime.ToExactNaturalText(toTime, al_ci);
+
+            Assert.NotNull(naturalText);
+            Assert.IsNotEmpty(naturalText);
+            Assert.AreEqual("2 vite, 2 muaj, 3 ditë, 4 orë, 5 minuta, 6 sekonda", naturalText);
+        }
+
+        [Test]
+        public void can_pluralize_years_al()
+        {
+            var toTime_plural = fromTime.AddYears(2);
+            var toTime_single = fromTime.AddYears(1);
+
+            var naturalText_plural = fromTime.ToNaturalText(toTime_plural, true, al_ci);
+            var naturalText_single = fromTime.ToNaturalText(toTime_single, true, al_ci);
+
+            Assert.AreEqual("2 vite", naturalText_plural); 
+            Assert.AreEqual("1 vit", naturalText_single);   
+        }
+
+        [Test]
+        public void can_pluralize_months_al()
+        {
+            var toTime_plural = fromTime.AddMonths(2);
+            var toTime_single = fromTime.AddMonths(1);
+
+            var naturalText_plural = fromTime.ToNaturalText(toTime_plural, true, al_ci);
+            var naturalText_single = fromTime.ToNaturalText(toTime_single, true, al_ci);
+
+            Assert.AreEqual("2 muaj", naturalText_plural); 
+            Assert.AreEqual("1 muaj", naturalText_single); 
+        }
+
+        [Test]
+        public void can_pluralize_days_al()
+        {
+            var toTime_plural = fromTime.AddDays(2);
+            var toTime_single = fromTime.AddDays(1);
+
+            var naturalText_plural = fromTime.ToNaturalText(toTime_plural, true, al_ci);
+            var naturalText_single = fromTime.ToNaturalText(toTime_single, true, al_ci);
+
+            Assert.AreEqual("2 ditë", naturalText_plural);
+            Assert.AreEqual("1 ditë", naturalText_single); 
+        }
+    }
+}


### PR DESCRIPTION
Hello,
I have added the official Albanian public holidays that are recognized as rest days to the DateTimeExtension library. This update helps users working with Albanian calendars to accurately identify non-working days. Please review and let me know if any changes are needed. Thank you!