### PR TITLE
PR2/3 issue 154: optimize and add methods for Time object w/tests

### DIFF
--- a/src/DateTimeExtensions/TimeOfDay/Time.cs
+++ b/src/DateTimeExtensions/TimeOfDay/Time.cs
@@ -21,10 +21,11 @@
 using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DateTimeExtensions.TimeOfDay
 {
-    public readonly struct Time : IComparable<Time>
+    public readonly struct Time : IComparable<Time>, IEquatable<Time>
     {
         //TODO: netstandart 1.1 don't support RegexOptions.Compiled, but a compiler directive for futher versions might enable this
         //private readonly static Regex ParseRegex = new Regex(@"^(0*[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$", RegexOptions.Compiled);
@@ -32,7 +33,7 @@ namespace DateTimeExtensions.TimeOfDay
 
         private readonly string _formatString;
         public string FormatString => _formatString ?? string.Empty;
-        /* Without the null forgiving operator or the backing field, 'default' would
+        /* Without the null forgiving operator or the backing field, 'default' will
             produce an instance with a null '_formatString', creating problems for ToString().
             TODO: Would be best to remove both the backing field and it's property, passing
             the argument directly to ToString (modifies the public API) */
@@ -42,6 +43,14 @@ namespace DateTimeExtensions.TimeOfDay
         public int Minute { get; }
 
         public int Second { get; }
+
+        public static Time Midnight { get; } = default; // 00:00:00
+
+        public static Time MinValue { get; } = default; // 00:00:00
+
+        public static Time Noon { get; } = new(12, 0, 0);
+
+        public static Time MaxValue { get; } = new(23, 59, 59);
 
         public Time(int hour = 0, int minute = 0, int second = 0, string formatString = "")
         {
@@ -84,9 +93,19 @@ namespace DateTimeExtensions.TimeOfDay
 
         public override string ToString()
         {
+            return ToString(FormatString);
+        }
+
+        public string ToString(string formatString)
+        {
+            if (formatString is null)
+            {
+                throw new ArgumentNullException(nameof(formatString));
+            }
+
             var today = DateTime.Today;
             var dateTime = new DateTime(today.Year, today.Month, today.Day, Hour, Minute, Second);
-            return dateTime.ToString(FormatString);
+            return dateTime.ToString(formatString);
         }
 
         public int CompareTo(Time other)
@@ -113,15 +132,72 @@ namespace DateTimeExtensions.TimeOfDay
             return 0;
         }
 
+        /// <summary>
+        /// Converts the string representation of the time of the day into a Time type.
+        /// The return will indicate success or failure
+        /// </summary>
+        /// <returns>true if the conversion was successful, false otherwise</returns>
+        public static bool TryParse(string valueString, out Time time)
+        {
+            time = default;
+
+            if (valueString is null)
+            {
+                return false;
+            }
+
+            var match = ParseRegex.Match(valueString);
+
+            if (!match.Success || match.Groups.Count != 4
+                || !int.TryParse(match.Groups[1].Value, out int hour)
+                || !int.TryParse(match.Groups[2].Value, out int minute)
+                || !int.TryParse(match.Groups[3].Value, out int second))
+            {
+                return false;
+            }
+
+            time = new(hour, minute, second);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Converts the string representation of the time of the day into a Time type.
+        /// </summary>
+        /// <returns>The Time type representing the given string</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         public static Time Parse(string valueString)
         {
-            var match = ParseRegex.Match(valueString);
-            if (!match.Success || match.Groups.Count != 4)
+            if (valueString is null)
+            {
+                throw new ArgumentNullException(nameof(valueString));
+            }
+
+            if (!TryParse(valueString, out Time time))
             {
                 throw new ArgumentException("Value string was not a correct time format", nameof(valueString));
             }
-            return new Time(
-                int.Parse(match.Groups[1].Value), int.Parse(match.Groups[2].Value), int.Parse(match.Groups[3].Value));
+
+            return time;
         }
+
+        public bool Equals(Time other) => CompareTo(other) == 0;
+
+        public override bool Equals([NotNullWhen(true)] object obj) => obj is Time other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Hour, Minute, Second);
+
+        public static bool operator ==(Time left, Time right) => left.Equals(right);
+
+        public static bool operator !=(Time left, Time right) => !left.Equals(right);
+
+        public static bool operator >(Time left, Time right) => left.CompareTo(right) > 0;
+
+        public static bool operator <(Time left, Time right) => left.CompareTo(right) < 0;
+
+        public static bool operator >=(Time left, Time right) => left.CompareTo(right) >= 0;
+
+        public static bool operator <=(Time left, Time right) => left.CompareTo(right) <= 0;
     }
 }

--- a/tests/DateTimeExtensions.Tests/TimeTests.cs
+++ b/tests/DateTimeExtensions.Tests/TimeTests.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using DateTimeExtensions;
-using DateTimeExtensions.TimeOfDay;
 using NUnit.Framework;
+using System.Globalization;
+using DateTimeExtensions.TimeOfDay;
 
 namespace DateTimeExtensions.Tests
 {
@@ -121,6 +116,105 @@ namespace DateTimeExtensions.Tests
             Assert.IsTrue(middleDate.IsBetween(endTime, startTime));
             Assert.IsTrue(beforeDate.IsBetween(startTime, endTime));
             Assert.IsTrue(aftereDate.IsBetween(startTime, endTime));
+        }
+
+        [Test]
+        public void can_compare_greater_operator()
+        {
+            Time t1 = new(14, 25);
+            Time t2 = Time.Noon;
+
+            bool t1IsGreater = t1 > t2;
+
+            Assert.That(t1IsGreater, Is.True);
+        }
+
+        [TestCase(12, 0, 10, 33)]
+        [TestCase(13, 37, 13, 37)]
+        public void can_compare_greater_or_equal_operator(int h1, int m1, int h2, int m2)
+        {
+            Time t1 = new(h1, m1);
+            Time t2 = new(h2, m2);
+
+            bool t1IsGreaterOrEqual = t1 >= t2;
+
+            Assert.That(t1IsGreaterOrEqual, Is.True);
+        }
+
+        [Test]
+        public void can_compare_lower_operator()
+        {
+            Time t1 = Time.Midnight;
+            Time t2 = new(17, 25, 33);
+
+            bool t1IsLower = t1 < t2;
+
+            Assert.That(t1IsLower, Is.True);
+        }
+
+        [TestCase(4, 0, 17, 21)]
+        [TestCase(0, 0, 0, 0)]
+        public void can_compare_lower_or_equal_operator(int h1, int m1, int h2, int m2)
+        {
+            Time t1 = new(h1, m1);
+            Time t2 = new(h2, m2);
+
+            bool t1IsLowerOrEqual = t1 <= t2;
+
+            Assert.That(t1IsLowerOrEqual, Is.True);
+        }
+
+        [Test]
+        public void can_compare_equal_operator()
+        {
+            Time t1 = Time.Noon;
+            Time t2 = new(12, 0);
+
+            bool t1IsEqualTot2 = t1 == t2;
+
+            Assert.That(t1IsEqualTot2, Is.True);
+        }
+
+        [Test]
+        public void can_compare_not_equal_operator()
+        {
+            Time t1 = new(12, 13, 14);
+            Time t2 = new(23, 59, 59);
+
+            bool t1IsNotEqualTot2 = t1 != t2;
+
+            Assert.That(t1IsNotEqualTot2, Is.True);
+        }
+
+        [Test]
+        public void can_try_parse()
+        {
+            string timeString = "12:27:55";
+
+            bool successfulParse = Time.TryParse(timeString, out Time notDefaultTime);
+
+            bool resultingTimeIsNotDefault = notDefaultTime != default;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(successfulParse, Is.True);
+                Assert.That(resultingTimeIsNotDefault, Is.True);
+            });
+        }
+
+        [TestCase("61:32:cherry")]
+        [TestCase(null)]
+        public void cant_try_parse(string s)
+        {
+            bool failedParse = Time.TryParse(s, out Time defaultTime) == false;
+
+            bool resultTimeIsDefault = defaultTime == default;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(failedParse, Is.True);
+                Assert.That(resultTimeIsDefault, Is.True);
+            });
         }
     }
 }


### PR DESCRIPTION
- Time now implements IEquatable<Time> for better efficiency and clarity
- Overload of the operators ==, !=, >, >=, <, <= to easily compare times
- Added TryParse method from string
- Static instances such as Time.Midnight, Time.Noon, Time.MinValue and Time.MaxValue
- Overload of ToString(string formatString)
- Tests

These changes do not modify the public API but add more functionalities, some of which will be used to refactor the Extension file cited in issue 154