### PR TITLE
docs: add release notes and changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
-Changelog
-===================
+# Changelog
+
+## Unreleased
+
+- No changes documented yet.
+
+## [v6.0.3](https://github.com/joaomatossilva/DateTimeExtensions/releases/tag/v6.0.3)
+
+- Optimized and refactored the time extension methods ([#285](https://github.com/joaomatossilva/DateTimeExtensions/pull/285)).
+
+## [v6.0.2](https://github.com/joaomatossilva/DateTimeExtensions/releases/tag/v6.0.2)
+
+- Optimized the `Time` type and added methods with tests ([#284](https://github.com/joaomatossilva/DateTimeExtensions/pull/284)).
+
+## [v6.0.1](https://github.com/joaomatossilva/DateTimeExtensions/releases/tag/v6.0.1)
+
+- Optimized and refactored the `Time` type ([#283](https://github.com/joaomatossilva/DateTimeExtensions/pull/283)).
+
+## [v6.0.0](https://github.com/joaomatossilva/DateTimeExtensions/releases/tag/v6.0.0)
+
+- Introduced the v6 breaking changes documented in [v6.md](v6.md), including the move from holiday-based types to observances and composed day resolvers ([#281](https://github.com/joaomatossilva/DateTimeExtensions/pull/281)).
+
 v5.5.7
 - Fixed de-AT with GoodFriday not being an holiday, thanks @cknabb Fixes #119
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Install DateTimeExtensions via [NuGet](https://learn.microsoft.com/en-us/nuget/r
 Install-Package DateTimeExtensions
 ```
 
+## 📝 Release Notes
+
+See the [changelog](CHANGELOG.md) for release information.
+
 ## 🚀 Quick Start
 
 Here are some examples of what you can do with DateTimeExtensions:

--- a/src/DateTimeExtensions/DateTimeExtensions.csproj
+++ b/src/DateTimeExtensions/DateTimeExtensions.csproj
@@ -8,6 +8,7 @@
     <PackageId>DateTimeExtensions</PackageId>
     <PackageTags>Natural;Date;Time;Relative;Calendar;Holiday;Workingday;DateTime</PackageTags>
     <PackageProjectUrl>https://github.com/joaomatossilva/DateTimeExtensions/wiki</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/joaomatossilva/DateTimeExtensions/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/joaomatossilva/datetimeextensions</RepositoryUrl>


### PR DESCRIPTION
## Summary

- document verified v6.0.0 through v6.0.3 changes in the existing changelog
- add an Unreleased section for future release notes
- link the changelog from the README
- expose the changelog through NuGet `PackageReleaseNotes` metadata

## Scope

This is a documentation and package-metadata-only change. It does not modify runtime behavior, dependencies, target frameworks, or package versioning.

Historical entries were based only on existing tags, merged pull requests, commits, and `v6.md`.

## Validation

- `dotnet build --no-restore`
- `dotnet test --no-build` — 387 tests passed
- `dotnet pack src/DateTimeExtensions/DateTimeExtensions.csproj --no-build --output ./artifacts`
- verified the generated `.nuspec` contains the changelog URL in `<releaseNotes>`

The pack command reports the existing `NU5125` and `NU5048` warnings for deprecated package metadata. Those warnings are outside the scope of this change.

Closes #282
